### PR TITLE
Recipe tweaks

### DIFF
--- a/scripts/MinecraftRecipes.zs
+++ b/scripts/MinecraftRecipes.zs
@@ -13,6 +13,13 @@ recipes.removeShaped(<minecraft:piston>);
 recipes.addShaped(<minecraft:piston>, [[<ore:plankWood>,<ore:plankWood>,<ore:plankWood>],[<minecraft:stone>,<minecraft:chest>,<minecraft:stone>],[<minecraft:redstone>,<minecraft:heavy_weighted_pressure_plate>,<minecraft:redstone>]]);
 recipes.removeShaped(<minecraft:wheat> * 9, [[<minecraft:hay_block>]]);
 
+# Shaped seeds to avoid conflict with Natura wheat flour
+recipes.removeShapeless(<minecraft:wheat_seeds>);
+recipes.addShaped(<minecraft:wheat_seeds>,
+[[<minecraft:wheat>, null, null], [null, null, null], [null, null, null]]
+);
+
+
 # Mushroom Stew conversion
 recipes.addShapeless(<minecraft:mushroom_stew>, [<Natura:natura.stewbowl>]);
 recipes.addShapeless(<Natura:natura.stewbowl>, [<minecraft:mushroom_stew>]);

--- a/scripts/Natura.zs
+++ b/scripts/Natura.zs
@@ -15,4 +15,10 @@ mods.botania.ManaInfusion.addAlchemy(<Natura:florasapling:6>,<Natura:florasaplin
 recipes.remove(<Natura:Obelisk>);
 recipes.addShaped(<Natura:Obelisk>, [[<Natura:tree:2>,<Natura:tree:2>,<Natura:tree:2>],[<Natura:tree:2>,<Thaumcraft:ItemResource:0>,<Natura:tree:2>],[<Natura:tree:2>,<Natura:tree:2>,<Natura:tree:2>]]);
 
+# Shaped wheat flour to avoid conflict with Vanilla seeds
+recipes.remove(<Natura:barleyFood:2>);
+recipes.addShaped(<Natura:barleyFood:2>,
+[[null, <minecraft:wheat>], [null, null, null], [null, null, null]]
+);
+
 print("ENDING Natura.zs");

--- a/scripts/SimplyJetpacks.zs
+++ b/scripts/SimplyJetpacks.zs
@@ -39,6 +39,13 @@ recipes.addShaped(<simplyjetpacks:components:25>, [[<simplyjetpacks:components:7
 recipes.remove(<simplyjetpacks:armorPlatings:11>);
 recipes.addShaped(<simplyjetpacks:armorPlatings:11>, [[<appliedenergistics2:item.ItemMultiMaterial:20>,<minecraft:heavy_weighted_pressure_plate>,<appliedenergistics2:item.ItemMultiMaterial:20>],[<minecraft:iron_ingot>,<appliedenergistics2:item.ItemMultiMaterial:20>,<minecraft:iron_ingot>],[<appliedenergistics2:item.ItemMultiMaterial:20>,<minecraft:heavy_weighted_pressure_plate>,<appliedenergistics2:item.ItemMultiMaterial:20>]]);
 
+# EnderIO Jetpacks
+recipes.addShaped(<simplyjetpacks:jetpacksEIO:4>, [
+  [<EnderIO:itemAlloy:2>, <EnderIO:itemBasicCapacitor:2>, <EnderIO:itemAlloy:2>],
+  [<EnderIO:itemAlloy:2>, <simplyjetpacks:jetpacksEIO:3>, <EnderIO:itemAlloy:2>],
+  [<simplyjetpacks:components:24>, null, <simplyjetpacks:components:24>],
+]);
+
 # Flux Packs
 recipes.remove(<simplyjetpacks:fluxpacks:2>);
 recipes.addShaped(<simplyjetpacks:fluxpacks:2>, [[<ore:blockGlass>,<ore:gearInvar>,<ore:blockGlass>],[<ThermalFoundation:material:72>,<simplyjetpacks:fluxpacks:1>,<ThermalFoundation:material:72>],[<ore:blockGlass>,<ore:gearInvar>,<ore:blockGlass>]]);
@@ -51,6 +58,11 @@ recipes.addShapeless(<simplyjetpacks:fluxpacks:4>, [<simplyjetpacks:fluxpacks:10
 # Capacitor Packs
 recipes.remove(<simplyjetpacks:fluxpacksEIO:2>);
 recipes.addShaped(<simplyjetpacks:fluxpacksEIO:2>, [[<EnderIO:itemBasicCapacitor:1>,<EnderIO:blockCapBank:1>,<EnderIO:itemBasicCapacitor:1>],[<EnderIO:itemAlloy:0>,<simplyjetpacks:fluxpacksEIO:1>,<EnderIO:itemAlloy:0>],[<EnderIO:itemAlloy:0>,<ore:dustGold>,<EnderIO:itemAlloy:0>]]);
+recipes.addShaped(<simplyjetpacks:fluxpacksEIO:4>, [
+  [<EnderIO:itemBasicCapacitor:2>, <EnderIO:blockCapBank:3>, <EnderIO:itemBasicCapacitor:2>],
+  [<EnderIO:itemAlloy:2>, <simplyjetpacks:fluxpacksEIO:3>, <EnderIO:itemAlloy:2>],
+  [<EnderIO:itemAlloy:2>, <EnderIO:itemMaterial:6>, <EnderIO:itemAlloy:2>],
+]);
 
 # Creative Flux Pack
 mods.avaritia.ExtremeCrafting.addShaped(<simplyjetpacks:fluxpacksCommon:9001>, 

--- a/scripts/TinkersConstruct.zs
+++ b/scripts/TinkersConstruct.zs
@@ -10,7 +10,11 @@ recipes.addShaped(<TConstruct:FurnaceSlab>, [[<minecraft:cobblestone>, <minecraf
 
 # Blank Pattern
 recipes.remove(<TConstruct:blankPattern>);
-recipes.addShapedMirrored(<TConstruct:blankPattern> * 4, [[<ore:plankWood>,<ore:plankWood>,<ore:stickWood>],[<ore:plankWood>,<ore:ingotIron>,<ore:plankWood>],[<ore:stickWood>,<ore:plankWood>,<ore:plankWood>]]);
+recipes.addShapedMirrored(<TConstruct:blankPattern> * 4, [
+  [<ore:plankWood>,<ore:plankWood>,<ore:stickWood>],
+  [<ore:plankWood>,<AWWayofTime:bloodMagicBaseItems:3>,<ore:plankWood>],
+  [<ore:stickWood>,<ore:plankWood>,<ore:plankWood>]
+]);
 
 # Smeltery
 recipes.remove(<TConstruct:Smeltery:0>);


### PR DESCRIPTION
- change blank pattern recipe to avoid "soft-block" by having to loot a village or other workarounds

![image](https://github.com/user-attachments/assets/45466e38-37c0-4c52-ad6f-9b2db3e20b66)
![image](https://github.com/user-attachments/assets/2ae05929-6e3a-4e8b-919d-4b90d6984006)

- fix conflict of wheat recipes from Vanilla MC and Natura
  - now it's not craftable in-inventory, only in a 3x3 crafting window but I guess that's the price to pay
 
![image](https://github.com/user-attachments/assets/0164e0f8-ede3-466e-99d0-703b740f98aa)
- add missing recipes for vibrant jetpack and octadic capacitor pack
  - analogically to previous tiers (energetic jetpack, quadruple-layered capacitor pack)

![image](https://github.com/user-attachments/assets/34be319e-f9ed-4050-8679-de3679862c67)
![image](https://github.com/user-attachments/assets/451f370e-b1ae-42de-b458-4e5f5180d248)

